### PR TITLE
Focal Operations of Immediate Neighbours

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -62,7 +62,7 @@ main = do
     --   , bench "strict P . lazy" $ nf (_array . strict P . lazy) img
     --   ]
     , bgroup "Local Operations"
-      [ bench "lmax" $ nf (_array . strict S . lmax img) img
+      [ -- bench "lmax" $ nf (_array . strict S . lmax img) img
         -- bench "classify 256" $ nf (classify (PixelRGBA8 0 0 0 0) gray) small
       ]
     -- , bgroup "HMatrix"
@@ -78,9 +78,12 @@ main = do
     , bgroup "Focal Operations"
       [ bench "fsum"  $ nf (_array . strict S . fsum) img
       -- , bench "fmean" $ nf (_array . strict S . fmean) img
-      , bgroup "faspect"
-        [ bench "Unsafe" $ nf (_array . strict S . faspect') img
-        , bench "Safe"   $ nf (_array . strict B . faspect) img
+      -- , bgroup "faspect"
+      --   [ bench "Unsafe" $ nf (_array . strict S . faspect') img
+      --   , bench "Safe"   $ nf (_array . strict B . faspect) img
+      --   ]
+      , bgroup "fdownstream"
+        [ bench "Set" $ nf (_array . strict B . fdownstream) img
         ]
       ]
     ]

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -3,11 +3,13 @@
 module Main where
 
 import           Criterion.Main
-import           Data.Maybe (fromJust)
 import qualified Data.Map.Lazy as M
+import           Data.Maybe (fromJust)
+import           Data.Monoid ((<>))
 import qualified Data.Vector.Unboxed as U
 import           Data.Word
 import           Geography.MapAlgebra
+import qualified Numeric.LinearAlgebra as LA
 
 ---
 
@@ -57,6 +59,11 @@ main = defaultMain
     , bgroup "Local Operations"
       [
         -- bench "classify 256" $ nf (classify (PixelRGBA8 0 0 0 0) gray) small
+      ]
+    , bgroup "HMatrix"
+      [ bench "linearSolveLS" $ nf (LA.linearSolveLS zing) (LA.col [8,8,8,8,8,8,8,8,8])
+      , bench "manual - MxM"  $ nf (leftPseudo <>) (LA.col [8,8,8,8,8,8,8,8,8])
+      , bench "manual - MxV"  $ nf (leftPseudo LA.#>) (LA.vector [8,8,8,8,8,8,8,8,8])
       ]
   ]
 

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -4,7 +4,6 @@ module Main where
 
 import           Criterion.Main
 import           Data.Massiv.Array as A
-import           Data.Monoid ((<>))
 import           Data.Word (Word8)
 import           Geography.MapAlgebra
 import qualified Numeric.LinearAlgebra as LA
@@ -83,8 +82,10 @@ main = do
       --   , bench "Safe"   $ nf (_array . strict B . faspect) img
       --   ]
       , bgroup "fdownstream"
-        [ bench "Set"  $ nf (_array . strict B . fdownstream) img
-        , bench "Word" $ nf (_array . strict P . fdownstream') img
+        [ bench "Word" $ nf (_array . strict S . fdownstream) img
+        ]
+      , bgroup "fupstream"
+        [ bench "Word" $ nf (_array . strict S . fupstream . strict S . fdownstream) img
         ]
       ]
     ]

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -2,7 +2,6 @@
 
 module Main where
 
-import           Codec.Picture
 import           Criterion.Main
 import           Data.Maybe (fromJust)
 import qualified Data.Map.Lazy as M
@@ -41,7 +40,7 @@ main = defaultMain
       ]
     , bgroup "RGBA"
       [
-        bench "generateImage - 256"  $ nf pixelImg 256
+        -- bench "generateImage - 256"  $ nf pixelImg 256
       -- , bench "generateImage - 1024" $ nf pixelImg 1024
       -- , bench "encodePng - 256"  $ nf encodePng rgba256
       -- , bench "encodePng - 1024" $ nf encodePng rgba1024
@@ -61,40 +60,40 @@ main = defaultMain
       ]
   ]
 
-small :: Raster p 256 256 Int
-small = fromFunction (*)
+-- small :: Raster p 256 256 Int
+-- small = fromFunction (*)
 
-smallV :: Raster p 256 256 Word8
-smallV = fromJust . fromUnboxed $ U.replicate (256*256) 1
+-- smallV :: Raster p 256 256 Word8
+-- smallV = fromJust . fromUnboxed $ U.replicate (256*256) 1
 
-big :: Raster p 1024 1024 Int
-big = fromFunction (*)
+-- big :: Raster p 1024 1024 Int
+-- big = fromFunction (*)
 
-bigV :: Raster p 1024 1024 Word8
-bigV = fromJust . fromUnboxed $ U.replicate (1024*1024) 1
+-- bigV :: Raster p 1024 1024 Word8
+-- bigV = fromJust . fromUnboxed $ U.replicate (1024*1024) 1
 
-cmap :: M.Map Int PixelRGBA8
-cmap = greenRed [1, 10, 100, 1000, 10000, 20000, 30000, 40000, 50000, 60000]
+-- cmap :: M.Map Int PixelRGBA8
+-- cmap = greenRed [1, 10, 100, 1000, 10000, 20000, 30000, 40000, 50000, 60000]
 
-pixels256 :: Raster p 256 256 PixelRGBA8
-pixels256 = constant $ PixelRGBA8 125 125 125 maxBound
+-- pixels256 :: Raster p 256 256 PixelRGBA8
+-- pixels256 = constant $ PixelRGBA8 125 125 125 maxBound
 -- pixels256 = classify (PixelRGBA8 0 0 0 0) gray small
 
-pixels1024 :: Raster p 1024 1024 PixelRGBA8
-pixels1024 = constant $ PixelRGBA8 125 125 125 maxBound
+-- pixels1024 :: Raster p 1024 1024 PixelRGBA8
+-- pixels1024 = constant $ PixelRGBA8 125 125 125 maxBound
 -- pixels1024 = classify (PixelRGBA8 0 0 0 0) gray big
 
-gray256 :: Image Word8
-gray256 = generateImage (\_ _ -> 125) 256 256
+-- gray256 :: Image Word8
+-- gray256 = generateImage (\_ _ -> 125) 256 256
 
-gray1024 :: Image Word8
-gray1024 = generateImage (\_ _ -> 125) 1024 1024
+-- gray1024 :: Image Word8
+-- gray1024 = generateImage (\_ _ -> 125) 1024 1024
 
-pixelImg :: Int -> Image PixelRGBA8
-pixelImg n = generateImage (\_ _ -> PixelRGBA8 125 125 125 maxBound) n n
+-- pixelImg :: Int -> Image PixelRGBA8
+-- pixelImg n = generateImage (\_ _ -> PixelRGBA8 125 125 125 maxBound) n n
 
-rgba256 :: Image PixelRGBA8
-rgba256 = pixelImg 256
+-- rgba256 :: Image PixelRGBA8
+-- rgba256 = pixelImg 256
 
-rgba1024 :: Image PixelRGBA8
-rgba1024 = pixelImg 1024
+-- rgba1024 :: Image PixelRGBA8
+-- rgba1024 = pixelImg 1024

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds, TypeApplications #-}
 
 module Main where
 
 import           Criterion.Main
-import qualified Data.Map.Lazy as M
-import           Data.Maybe (fromJust)
+import           Data.Massiv.Array as A
 import           Data.Monoid ((<>))
-import qualified Data.Vector.Unboxed as U
-import           Data.Word
+import           Data.Word (Word8)
 import           Geography.MapAlgebra
 import qualified Numeric.LinearAlgebra as LA
 
 ---
 
 main :: IO ()
-main = defaultMain
-  [ bgroup "Encoding"
-    [ bgroup "Grayscale"
-      [
+main = do
+  img <- fileY
+  defaultMain
+    [ bgroup "Encoding"
+      [ bgroup "Grayscale"
+        [
       --   bench "encodePng - 256"  $ nf encodePng gray256
       -- , bench "encodePng - 1024" $ nf encodePng gray1024
 
@@ -39,9 +39,9 @@ main = defaultMain
       -- , bench "TIFF 1024 Constant"    $ nf (encodeTiff . grayscale) (constant 125 :: Raster p 1024 1024 Word8)
       -- , bench "TIFF 1024 fromList"    $ nf (encodeTiff . grayscale) big
       -- , bench "TIFF 1024 fromUnboxed" $ nf (encodeTiff . grayscale) bigV
-      ]
-    , bgroup "RGBA"
-      [
+        ]
+      , bgroup "RGBA"
+        [
         -- bench "generateImage - 256"  $ nf pixelImg 256
       -- , bench "generateImage - 1024" $ nf pixelImg 1024
       -- , bench "encodePng - 256"  $ nf encodePng rgba256
@@ -54,18 +54,47 @@ main = defaultMain
       -- , bench "rgba - 256 - 2 ops"  $ nf (\r -> encodePng . rgba . classify invisible cmap $ r + r + r) small
       -- , bench "rgba - 1024" $ nf (encodePng . rgba . classify invisible cmap) big
       -- , bench "rgba - 1024 - 2 ops"  $ nf (\r -> encodePng . rgba . classify invisible cmap $ r + r + r) big
+        ]
       ]
-    ]
+    -- , bgroup "Massiv Operations"
+    --   [ bench "strict S . lazy" $ nf (_array . strict S . lazy) img
+    --   , bench "strict U . lazy" $ nf (_array . strict U . lazy) img
+    --   , bench "strict P . lazy" $ nf (_array . strict P . lazy) img
+    --   ]
     , bgroup "Local Operations"
-      [
+      [ bench "lmax" $ nf (_array . strict S . lmax img) img
         -- bench "classify 256" $ nf (classify (PixelRGBA8 0 0 0 0) gray) small
       ]
-    , bgroup "HMatrix"
-      [ bench "linearSolveLS" $ nf (LA.linearSolveLS zing) (LA.col [8,8,8,8,8,8,8,8,8])
-      , bench "manual - MxM"  $ nf (leftPseudo <>) (LA.col [8,8,8,8,8,8,8,8,8])
-      , bench "manual - MxV"  $ nf (leftPseudo LA.#>) (LA.vector [8,8,8,8,8,8,8,8,8])
+    -- , bgroup "HMatrix"
+    --   [ bench "linearSolveLS" $ nf (LA.linearSolveLS zing) (LA.col [8,8,8,8,8,8,8,8,8])
+    --   , bench "manual - MxM"  $ nf (leftPseudo <>) (LA.col [8,8,8,8,8,8,8,8,8])
+    --   , bench "manual - MxV"  $ nf (leftPseudo LA.#>) (LA.vector [8,8,8,8,8,8,8,8,8])
+    --   ]
+    -- , bgroup "Numeric Conversion"
+    --   [ bench "Double -> Double via id"         $ nf id tau
+    --   , bench "Double -> Double via realToFrac" $ nf (realToFrac @Double @Double) tau
+    --   , bench "Word -> Double via realToFrac"   $ nf (realToFrac @Word8 @Double) 5
+    --   ]
+    , bgroup "Focal Operations"
+      [ bench "fsum"  $ nf (_array . strict S . fsum) img
+      -- , bench "fmean" $ nf (_array . strict S . fmean) img
+      , bgroup "faspect"
+        [ bench "Unsafe" $ nf (_array . strict S . faspect') img
+        , bench "Safe"   $ nf (_array . strict B . faspect) img
+        ]
       ]
-  ]
+    ]
+
+zing :: LA.Matrix Double
+zing = LA.matrix 3 [ -0.5, -0.5, 1
+                   , -0.5, 0, 1
+                   , -0.5, 0.5, 1
+                   , 0, -0.5, 1
+                   , 0, 0, 1
+                   , 0, 0.5, 1
+                   , 0.5, -0.5, 1
+                   , 0.5, 0, 1
+                   , 0.5, 0.5, 1 ]
 
 -- small :: Raster p 256 256 Int
 -- small = fromFunction (*)
@@ -104,3 +133,12 @@ main = defaultMain
 
 -- rgba1024 :: Image PixelRGBA8
 -- rgba1024 = pixelImg 1024
+
+
+-- fileY :: IO (Raster S p 1753 1760 Word8)
+fileY :: IO (Raster S p 512 512 Word8)
+fileY = do
+  i <- fromGray "/home/colin/code/haskell/mapalgebra/chatta.tif"
+  case i of
+    Left err  -> putStrLn err *> pure (constant S Par 8)
+    Right img -> pure img

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -83,7 +83,8 @@ main = do
       --   , bench "Safe"   $ nf (_array . strict B . faspect) img
       --   ]
       , bgroup "fdownstream"
-        [ bench "Set" $ nf (_array . strict B . fdownstream) img
+        [ bench "Set"  $ nf (_array . strict B . fdownstream) img
+        , bench "Word" $ nf (_array . strict P . fdownstream') img
         ]
       ]
     ]

--- a/lib/Geography/MapAlgebra.hs
+++ b/lib/Geography/MapAlgebra.hs
@@ -1126,20 +1126,17 @@ downstream :: [Double] -> S.Set Direction
 downstream ds@[nw, no, ne, we, fo, ea, sw, so, se]
   | length (filter (<= fo) ds) == 1 = S.empty  -- A pit. All neighbours are higher.
   | otherwise = snd . foldl' f (S.singleton <$> head angles) $ tail angles
-  where fo'  = LA.vector [0, 0, fo]
-        axis = LA.vector [0, 0, -1]
-        f (!curr, !s) (!a, !d) | a =~ curr = (curr, S.insert d s)
-                               | a <  curr = (a, S.singleton d)
+  where f (!curr, !s) (!a, !d) | a =~ curr = (curr, S.insert d s)
+                               | a >  curr = (a, S.singleton d)
                                | otherwise = (curr, s)
-        angles = [ (g [-0.5, -0.5, nw], NorthWest)
-                 , (g [-0.5, 0, no],    North)
-                 , (g [-0.5, 0.5, ne],  NorthEast)
-                 , (g [0, -0.5, we],    West)
-                 , (g [0, 0.5, ea],     East)
-                 , (g [0.5, -0.5, sw],  SouthWest)
-                 , (g [0.5, 0, so],     South)
-                 , (g [0.5, 0.5, se],   SouthEast) ]
-        g v = angle axis . LA.normalize $ LA.vector v - fo'
+        angles = [ (fo - nw, NorthWest)
+                 , (fo - no, North)
+                 , (fo - ne, NorthEast)
+                 , (fo - we, West)
+                 , (fo - ea, East)
+                 , (fo - sw, SouthWest)
+                 , (fo - so, South)
+                 , (fo - se, SouthEast) ]
 downstream _ = S.empty
 
 -- | Focal Drainage - upstream portion. This indicates the one of more compass

--- a/lib/Geography/MapAlgebra.hs
+++ b/lib/Geography/MapAlgebra.hs
@@ -1070,7 +1070,9 @@ zcoord :: Double -> LA.Vector Double -> LA.Vector Double
 zcoord n v = LA.vector [ v LA.! 0, v LA.! 1, n ]
 
 -- | Focal Aspect - the compass direction toward which the surface
--- descends most rapidly. Results are in radians, with TODO (talk about directions)
+-- descends most rapidly. Results are in radians, with 0 or \(\tau\) being North,
+-- \(\tau / 4\) being East, and so on. For areas that are essentially flat, their
+-- aspect will be `Nothing`.
 faspect :: (Real a, Manifest u Ix2 a, Default a) => Raster u p r c a -> Raster DW p r c (Maybe Double)
 faspect (Raster a) = Raster $ mapStencil (facetStencil f) a
   where f vs = case normal' vs of
@@ -1082,7 +1084,7 @@ faspect (Raster a) = Raster $ mapStencil (facetStencil f) a
 (=~) :: Double -> Double -> Bool
 a =~ b = abs (a - b) < 0.000001
 
--- | Like `faspect`, but maybe faster? Beware of nonsense results when the plane is flat.
+-- | Like `faspect`, but slightly faster. Beware of nonsense results when the plane is flat.
 faspect' :: (Real a, Manifest u Ix2 a, Default a) => Raster u p r c a -> Raster DW p r c Double
 faspect' (Raster a) = Raster $ mapStencil (facetStencil f) a
   where f vs = acos $ LA.dot (LA.normalize $ zcoord 0 $ normal' vs) axis

--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,6 @@ tests:
     ghc-options:
       - -threaded
       - -with-rtsopts=-N
-      - -O2
     dependencies:
       - mapalgebra
       - HUnit-approx >= 1.1 && < 1.2

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ tests:
       - -O2
     dependencies:
       - mapalgebra
+      - HUnit-approx >= 1.1 && < 1.2
       - tasty >= 0.11 && < 2.0
       - tasty-hunit >= 0.9 && < 0.11
       - tasty-quickcheck >= 0.8 && < 0.10

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ tests:
   mapalgebra-test:
     main: Test.hs
     source-dirs: test
+    other-modules: []
     ghc-options:
       - -threaded
       - -with-rtsopts=-N
@@ -58,6 +59,7 @@ benchmarks:
   mapalgebra-bench:
     main: Bench.hs
     source-dirs: bench
+    other-modules: []
     ghc-options:
       - -threaded
       - -O2

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 
 library:
   source-dirs: lib
+  other-modules: []
 
 tests:
   mapalgebra-test:

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - deepseq
   - massiv >= 0.1 && < 0.2
   - massiv-io >= 0.1 && < 0.2
+  - hmatrix >= 0.18 && < 0.19
   - vector >= 0.11 && < 0.13
 
 library:
@@ -53,6 +54,7 @@ tests:
       - tasty >= 0.11 && < 2.0
       - tasty-hunit >= 0.9 && < 0.11
       - tasty-quickcheck >= 0.8 && < 0.10
+      - QuickCheck
 
 benchmarks:
   mapalgebra-bench:

--- a/package.yaml
+++ b/package.yaml
@@ -61,5 +61,5 @@ benchmarks:
       - -O2
       - -with-rtsopts=-N
     dependencies:
-      - criterion >= 1.1 && < 1.3
+      - criterion >= 1.1 && < 1.4
       - mapalgebra

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.4
+resolver: lts-11.5
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,10 @@
-resolver: lts-11.3
+resolver: lts-11.4
 
 packages:
   - .
+
+extra-deps:
+  - git: https://github.com/lehins/massiv
+    commit: fa3f71099db90bdd6a0dd27c6447745c35d3df49
+    subdirs:
+      - massiv

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,5 @@ packages:
   - .
 
 extra-deps:
-  - git: https://github.com/lehins/massiv
-    commit: fa3f71099db90bdd6a0dd27c6447745c35d3df49
-    subdirs:
-      - massiv
+  - massiv-0.1.6.1
+  - massiv-io-0.1.2.0

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -162,10 +162,10 @@ fromRight _ = error "Was Left"
 
 fpartitionTest :: Assertion
 fpartitionTest = actual @?= expected
-  where expected :: Raster B p 2 2 Corners
-        expected = fromRight . fromVector Seq $ V.fromList [ Corners Self Self Self Self
-                                                           , Corners Self Self Self Self
-                                                           , Corners Self Self Self Other
-                                                           , Corners Self Self Self Self ]
-        actual :: Raster B p 2 2 Corners
-        actual = fromRight . fmap (strict B . fpartition) . fromVector Seq $ U.fromList ([1,1,2,1] :: [Int])
+  where expected :: Raster B p 2 2 (Corners Int)
+        expected = fromRight . fromVector Seq $ V.fromList [ Corners Open Open Open Open
+                                                           , Corners Open Open Open Open
+                                                           , Corners OneSide Open OneSide (Complete 1)
+                                                           , Corners Open Open Open Open ]
+        actual :: Raster B p 2 2 (Corners Int)
+        actual = fromRight . fmap (strict B . fpartition) . fromVector Seq $ U.fromList [1,1,2,1]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -81,6 +81,10 @@ suite = testGroup "Unit Tests"
       , testCase "3x3 Hill" fvolumeHill
       ]
     , testProperty "Least Squares" leastSquares
+    , testGroup "fgradient"
+      [ testCase "3x3 Flat" fgradientFlat
+      , testCase "3x3 (tau/8)" fgradient45
+      ]
     ]
   ]
 
@@ -279,3 +283,16 @@ zing = LA.matrix 3 [ -1, -1, 1
                    , 1, -1, 1
                    , 1, 0, 1
                    , 1, 1, 1 ]
+
+
+fgradientFlat :: Assertion
+fgradientFlat = actual @?= expected
+  where expected :: Raster U p 3 3 Double
+        expected = fromRight . fromVector Seq $ U.fromList [0,0,0,0,0,0,0,0,0]
+        actual :: Raster U p 3 3 Double
+        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList [1,1,1,1,1,1,1,1,1]
+
+fgradient45 :: Assertion
+fgradient45 = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?~ (tau / 8)
+  where actual :: Raster U p 3 3 Double
+        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList [3,3,3,2,2,2,1,1,1]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -67,6 +67,7 @@ suite = testGroup "Unit Tests"
       ]
     , testCase "flength" flengthTest
     , testCase "fpartition" fpartitionTest
+    , testCase "fareals" farealsTest
     ]
   ]
 
@@ -152,7 +153,7 @@ threeByThree = actual @?= expected
 flengthTest :: Assertion
 flengthTest = actual @?= expected
   where actual :: Raster U p 3 3 Double
-        actual = fromRight . fmap (strict U . flength . strict B . flinkage) . fromVector Seq $ V.fromList ([1,2,1,2,2,2,1,2,1] :: [Int])
+        actual = strict U . flength . strict B . flinkage . fromRight . fromVector Seq $ V.fromList ([1,2,1,2,2,2,1,2,1] :: [Int])
         expected :: Raster U p 3 3 Double
         expected = fromRight . fromVector Seq $ U.fromList [ 0, 3.5, 0, 3.5, 4, 3.5, 0, 3.5, 0 ]
 
@@ -168,4 +169,19 @@ fpartitionTest = actual @?= expected
                                                            , Corners OneSide Open OneSide (Complete 1)
                                                            , Corners Open Open Open Open ]
         actual :: Raster B p 2 2 (Corners Int)
-        actual = fromRight . fmap (strict B . fpartition) . fromVector Seq $ U.fromList [1,1,2,1]
+        actual = strict B . fpartition . fromRight . fromVector Seq $ U.fromList [1,1,2,1]
+
+farealsTest :: Assertion
+farealsTest = actual @?= expected
+ where expected :: Raster B p 3 3 (Corners Int)
+       expected = fromRight . fromVector Seq $ V.fromList [ Corners Open Open Open Open
+                                                          , Corners Open Open Open Open
+                                                          , Corners Open Open Open Open
+                                                          , Corners Open Open Open Open
+                                                          , Corners (Complete 1) (Complete 1) (Complete 1) (Complete 1)
+                                                          , Corners Open Open Open Open
+                                                          , Corners Open Open Open Open
+                                                          , Corners Open Open Open Open
+                                                          , Corners Open Open Open Open ]
+       actual :: Raster B p 3 3 (Corners Int)
+       actual = strict B . fareals . fromRight . fromVector Seq $ U.fromList [1,1,1,1,0,1,1,1,1]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,10 +8,10 @@ module Main ( main ) where
 import Data.Int
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Massiv.Array as A
-import Data.Massiv.Array.IO
+-- import Data.Massiv.Array.IO
 import Data.Word
 import Geography.MapAlgebra
-import Graphics.ColorSpace (RGBA)
+-- import Graphics.ColorSpace (RGBA)
 import Prelude as P
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -89,11 +89,11 @@ lazybig = constant D Par 5
 -- arr :: Array U Ix2 Int
 -- arr = A.fromVector Seq (2 :. 3) $ U.fromList [0..5]
 
-indices :: Raster D p 256 256 Int
-indices = fromFunction D Seq (\(r :. c) -> (r * 10) + c)
+-- indices :: Raster D p 256 256 Int
+-- indices = fromFunction D Seq (\(r :. c) -> (r * 10) + c)
 
-zoop :: Raster D p 256 256 Int
-zoop = fromFunction D Seq (\(r :. c) -> r * c)
+-- zoop :: Raster D p 256 256 Int
+-- zoop = fromFunction D Seq (\(r :. c) -> r * c)
 
 fileRGBA :: IO (Either String (RGBARaster p 1753 1760 Word8))
 fileRGBA = fromRGBA "/home/colin/code/haskell/mapalgebra/LC81750172014163LGN00_LOW5.TIF"
@@ -101,5 +101,5 @@ fileRGBA = fromRGBA "/home/colin/code/haskell/mapalgebra/LC81750172014163LGN00_L
 fileY :: IO (Either String (Raster D p 1753 1760 Word8))
 fileY = fromGray "/home/colin/code/haskell/mapalgebra/LC81750172014163LGN00_LOW5.TIF"
 
-colourIt :: Raster D p 256 256 Int -> Image D RGBA Word8
-colourIt = _array . classify invisible (greenRed [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000])
+-- colourIt :: Raster D p 256 256 Int -> Image D RGBA Word8
+-- colourIt = _array . classify invisible (greenRed [1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -75,6 +75,10 @@ suite = testGroup "Unit Tests"
       , testCase "3x3 Centre" fareaCentre
       , testCase "4x4 Complex" fareaComplex
       ]
+    , testGroup "fvolume"
+      [ testCase "3x3 Flat" fvolumeFlat
+      , testCase "3x3 Hill" fvolumeHill
+      ]
     ]
   ]
 
@@ -231,3 +235,17 @@ fareaComplex = let ?epsilon = 0.001 in actual @?~ (2 + (7 / 8) + (7 / 8) + (1 / 
                                                                            ,1,0,0,0
                                                                            ,1,0,0,1
                                                                            ,1,0,1,1]
+
+fvolumeFlat :: Assertion
+fvolumeFlat = (strict U $ fvolume expected) @?= expected
+  where expected :: Raster U p 3 3 Double
+        expected = fromRight . fromVector Seq $ U.fromList [8,8,8,8,8,8,8,8,8]
+
+fvolumeHill :: Assertion
+fvolumeHill = (flip index' (1 :. 1) $ _array actual) @?= expected
+  where expected :: Double
+        expected = P.sum [20,20,16,20,16,16,16,16,12,16,12,12] / 12
+        actual :: Raster U p 3 3 Double
+        actual = strict U . fvolume . fromRight . fromVector Seq $ U.fromList [24,24,24
+                                                                              ,16,16,16
+                                                                              ,8,8,8]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -278,16 +278,15 @@ leastSquares (Vec vs) = f 0 && f 1 && f 2
 a =~ b = abs (a - b) < 0.0001
 
 zing :: LA.Matrix Double
-zing = LA.matrix 3 [ -1, -1, 1
-                   , -1, 0, 1
-                   , -1, 1, 1
-                   , 0, -1, 1
+zing = LA.matrix 3 [ -0.5, -0.5, 1
+                   , -0.5, 0, 1
+                   , -0.5, 0.5, 1
+                   , 0, -0.5, 1
                    , 0, 0, 1
-                   , 0, 1, 1
-                   , 1, -1, 1
-                   , 1, 0, 1
-                   , 1, 1, 1 ]
-
+                   , 0, 0.5, 1
+                   , 0.5, -0.5, 1
+                   , 0.5, 0, 1
+                   , 0.5, 0.5, 1 ]
 
 fgradientFlat :: Assertion
 fgradientFlat = actual @?= expected
@@ -304,9 +303,9 @@ fgradient45 = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?
 faspectFlat :: Assertion
 faspectFlat = (flip index' (1 :. 1) $ _array actual) @?= Nothing
   where actual :: Raster B p 3 3 (Maybe Double)
-        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList [1,1,1,1,1,1,1,1,1]
+        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
 
 faspect45 :: Assertion
 faspect45 = (flip index' (1 :. 1) $ _array actual) @?= Just (tau / 2)
   where actual :: Raster B p 3 3 (Maybe Double)
-        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList [3,3,3,2,2,2,1,1,1]
+        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList ([3,3,3,2,2,2,1,1,1] :: [Double])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -66,6 +66,7 @@ suite = testGroup "Unit Tests"
       , testCase "3x3" threeByThree
       ]
     , testCase "flength" flengthTest
+    , testCase "fpartition" fpartitionTest
     ]
   ]
 
@@ -158,3 +159,13 @@ flengthTest = actual @?= expected
 fromRight :: Either a b -> b
 fromRight (Right b) = b
 fromRight _ = error "Was Left"
+
+fpartitionTest :: Assertion
+fpartitionTest = actual @?= expected
+  where expected :: Raster B p 2 2 Corners
+        expected = fromRight . fromVector Seq $ V.fromList [ Corners Self Self Self Self
+                                                           , Corners Self Self Self Self
+                                                           , Corners Self Self Self Other
+                                                           , Corners Self Self Self Self ]
+        actual :: Raster B p 2 2 Corners
+        actual = fromRight . fmap (strict B . fpartition) . fromVector Seq $ U.fromList ([1,1,2,1] :: [Int])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -85,6 +85,10 @@ suite = testGroup "Unit Tests"
       [ testCase "3x3 Flat" fgradientFlat
       , testCase "3x3 (tau/8)" fgradient45
       ]
+    , testGroup "faspect"
+      [ testCase "3x3 Flat" faspectFlat
+      , testCase "3x3 Hill" faspect45
+      ]
     ]
   ]
 
@@ -296,3 +300,13 @@ fgradient45 :: Assertion
 fgradient45 = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?~ (tau / 8)
   where actual :: Raster U p 3 3 Double
         actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList [3,3,3,2,2,2,1,1,1]
+
+faspectFlat :: Assertion
+faspectFlat = (flip index' (1 :. 1) $ _array actual) @?= Nothing
+  where actual :: Raster B p 3 3 (Maybe Double)
+        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList [1,1,1,1,1,1,1,1,1]
+
+faspect45 :: Assertion
+faspect45 = (flip index' (1 :. 1) $ _array actual) @?= Just (tau / 2)
+  where actual :: Raster B p 3 3 (Maybe Double)
+        actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList [3,3,3,2,2,2,1,1,1]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -327,31 +327,31 @@ faspectEast = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?
         actual = strict B . faspect' . fromRight . fromVector Seq $ U.fromList ([3,2,1,3,2,1,3,2,1] :: [Double])
 
 fdownstream4 :: Assertion
-fdownstream4 = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [North,South,East,West]
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([3,1,3,1,2,1,3,1,3] :: [Double])
+fdownstream4 = (flip index' (1 :. 1) $ _array actual) @?= drainage (S.fromList [North,South,East,West])
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([3,1,3,1,2,1,3,1,3] :: [Double])
 
 fdownstreamFlat :: Assertion
-fdownstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [East ..]
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
+fdownstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= drainage (S.fromList [East ..])
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
 
 fdownstreamPeak :: Assertion
-fdownstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [NorthEast, NorthWest, SouthWest, SouthEast]
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])
+fdownstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= drainage (S.fromList [NorthEast, NorthWest, SouthWest, SouthEast])
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])
 
 fdownstreamPit :: Assertion
-fdownstreamPit = (flip index' (1 :. 1) $ _array actual) @?= S.empty
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([2,2,2,2,1,2,2,2,2] :: [Double])
+fdownstreamPit = (flip index' (1 :. 1) $ _array actual) @?= Drain 0
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([2,2,2,2,1,2,2,2,2] :: [Double])
 
 fupstreamFlat :: Assertion
-fupstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [East ..]
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fupstream . strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
+fupstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= drainage (S.fromList [East ..])
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fupstream . strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
 
 fupstreamPeak :: Assertion
-fupstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= S.empty
-  where actual :: Raster B p 3 3 (S.Set Direction)
-        actual = strict B . fupstream . strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])
+fupstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= Drain 0
+  where actual :: Raster S p 3 3 Drain
+        actual = strict S . fupstream . strict S . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -65,6 +65,7 @@ suite = testGroup "Unit Tests"
       , testCase "2x2 diff" twoByTwoDiff
       , testCase "3x3" threeByThree
       ]
+    , testCase "flength" flengthTest
     ]
   ]
 
@@ -114,35 +115,46 @@ singlePoint = actual @?= expected
 
 twoByTwoSame :: Assertion
 twoByTwoSame = actual @?= expected
-  where expected :: Either String (Raster B p 2 2 (S.Set Direction))
-        expected = fromVector Seq . V.fromList $ P.map S.fromList [ [ East, South ]
-                                                                  , [ West, South ]
-                                                                  , [ North,East ]
-                                                                  , [ West, North ] ]
-        actual :: Either String (Raster B p 2 2 (S.Set Direction))
-        actual = fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,1,1,1] :: [Int])
+  where expected :: Raster B p 2 2 (S.Set Direction)
+        expected = fromRight . fromVector Seq . V.fromList $ P.map S.fromList [ [ East, South ]
+                                                                              , [ West, South ]
+                                                                              , [ North,East ]
+                                                                              , [ West, North ] ]
+        actual :: Raster B p 2 2 (S.Set Direction)
+        actual = fromRight . fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,1,1,1] :: [Int])
 
 twoByTwoDiff :: Assertion
 twoByTwoDiff = actual @?= expected
-  where expected :: Either String (Raster B p 2 2 (S.Set Direction))
-        expected = fromVector Seq . V.fromList $ P.map S.fromList [ [ SouthEast ]
-                                                                  , [ SouthWest ]
-                                                                  , [ NorthEast ]
-                                                                  , [ NorthWest ] ]
-        actual :: Either String (Raster B p 2 2 (S.Set Direction))
-        actual = fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,2,2,1] :: [Int])
+  where expected :: Raster B p 2 2 (S.Set Direction)
+        expected = fromRight . fromVector Seq . V.fromList $ P.map S.fromList [ [ SouthEast ]
+                                                                              , [ SouthWest ]
+                                                                              , [ NorthEast ]
+                                                                              , [ NorthWest ] ]
+        actual :: Raster B p 2 2 (S.Set Direction)
+        actual = fromRight . fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,2,2,1] :: [Int])
 
 threeByThree :: Assertion
 threeByThree = actual @?= expected
-  where expected :: Either String (Raster B p 3 3 (S.Set Direction))
-        expected = fromVector Seq . V.fromList $ P.map S.fromList [ [ ]
-                                                                  , [ South ]
-                                                                  , [ ]
-                                                                  , [ East ]
-                                                                  , [ North, West, South, East ]
-                                                                  , [ West ]
-                                                                  , [ ]
-                                                                  , [ North ]
-                                                                  , [ ] ]
-        actual :: Either String (Raster B p 3 3 (S.Set Direction))
-        actual = fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,2,1,2,2,2,1,2,1] :: [Int])
+  where expected :: Raster B p 3 3 (S.Set Direction)
+        expected = fromRight . fromVector Seq . V.fromList $ P.map S.fromList [ [ ]
+                                                                              , [ South ]
+                                                                              , [ ]
+                                                                              , [ East ]
+                                                                              , [ North, West, South, East ]
+                                                                              , [ West ]
+                                                                              , [ ]
+                                                                              , [ North ]
+                                                                              , [ ] ]
+        actual :: Raster B p 3 3 (S.Set Direction)
+        actual = fromRight . fmap (strict B . flinkage) . fromVector Seq $ U.fromList ([1,2,1,2,2,2,1,2,1] :: [Int])
+
+flengthTest :: Assertion
+flengthTest = actual @?= expected
+  where actual :: Raster U p 3 3 Double
+        actual = fromRight . fmap (strict U . flength . strict B . flinkage) . fromVector Seq $ V.fromList ([1,2,1,2,2,2,1,2,1] :: [Int])
+        expected :: Raster U p 3 3 Double
+        expected = fromRight . fromVector Seq $ U.fromList [ 0, 3.5, 0, 3.5, 4, 3.5, 0, 3.5, 0 ]
+
+fromRight :: Either a b -> b
+fromRight (Right b) = b
+fromRight _ = error "Was Left"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -94,6 +94,11 @@ suite = testGroup "Unit Tests"
       [ testCase "3x3 Spikey" fdownstream4
       , testCase "3x3 Flat" fdownstreamFlat
       , testCase "3x3 Peak" fdownstreamPeak
+      , testCase "3x3 Pit"  fdownstreamPit
+      ]
+    , testGroup "fupstream"
+      [ testCase "3x3 Peak" fupstreamPeak
+      , testCase "3x3 Flat" fupstreamFlat
       ]
     ]
   ]
@@ -335,3 +340,18 @@ fdownstreamPeak :: Assertion
 fdownstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [NorthEast, NorthWest, SouthWest, SouthEast]
   where actual :: Raster B p 3 3 (S.Set Direction)
         actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])
+
+fdownstreamPit :: Assertion
+fdownstreamPit = (flip index' (1 :. 1) $ _array actual) @?= S.empty
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([2,2,2,2,1,2,2,2,2] :: [Double])
+
+fupstreamFlat :: Assertion
+fupstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [East ..]
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fupstream . strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
+
+fupstreamPeak :: Assertion
+fupstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= S.empty
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fupstream . strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -68,8 +68,13 @@ suite = testGroup "Unit Tests"
       ]
     , testCase "flength" flengthTest
     , testCase "fpartition" fpartitionTest
-    , testCase "fareals" farealsTest
+    , testCase "fshape" fshapeTest
     , testCase "ffrontage" ffrontageTest
+    , testGroup "farea"
+      [ testCase "3x3 Open" fareaOpen
+      , testCase "3x3 Centre" fareaCentre
+      , testCase "4x4 Complex" fareaComplex
+      ]
     ]
   ]
 
@@ -173,8 +178,8 @@ fpartitionTest = actual @?= expected
         actual :: Raster B p 2 2 (Cell Int)
         actual = strict B . fpartition . fromRight . fromVector Seq $ U.fromList [1,1,2,1]
 
-farealsTest :: Assertion
-farealsTest = actual @?= expected
+fshapeTest :: Assertion
+fshapeTest = actual @?= expected
  where expected :: Raster B p 3 3 (Cell Int)
        expected = fromRight . fromVector Seq $ V.fromList [ Cell 1 $ Corners Open Open Open Open
                                                           , Cell 1 $ Corners Open Open Open Open
@@ -186,7 +191,7 @@ farealsTest = actual @?= expected
                                                           , Cell 1 $ Corners Open Open Open Open
                                                           , Cell 1 $ Corners Open Open Open Open ]
        actual :: Raster B p 3 3 (Cell Int)
-       actual = strict B . fareals . fromRight . fromVector Seq $ U.fromList [1,1,1,1,0,1,1,1,1]
+       actual = strict B . fshape . fromRight . fromVector Seq $ U.fromList [1,1,1,1,0,1,1,1,1]
 
 ffrontageTest :: Assertion
 ffrontageTest = let ?epsilon = 0.001 in actual @?~ expected
@@ -195,7 +200,34 @@ ffrontageTest = let ?epsilon = 0.001 in actual @?~ expected
         actual :: Double
         actual = flip index' (1 :. 1) . _array . strict P $ ffrontage rast
         rast :: Raster B p 4 4 (Cell Int)
-        rast = strict B . fareals . fromRight . fromVector Seq $ U.fromList [1,1,1,0
-                                                                            ,1,0,0,0
-                                                                            ,1,0,0,1
-                                                                            ,1,0,1,1]
+        rast = strict B . fshape . fromRight . fromVector Seq $ U.fromList [1,1,1,0
+                                                                           ,1,0,0,0
+                                                                           ,1,0,0,1
+                                                                           ,1,0,1,1]
+
+fareaOpen :: Assertion
+fareaOpen = actual @?= expected
+  where expected :: Raster U p 3 3 Double
+        expected = fromRight . fromVector Seq $ U.fromList [9,9,9,9,9,9,9,9,9]
+        actual :: Raster U p 3 3 Double
+        actual = strict U . farea . strict B . fshape . fromRight . fromVector Seq $ U.fromList ([0,0,0,0,0,0,0,0,0] :: [Int])
+
+fareaCentre :: Assertion
+fareaCentre = actual @?= expected
+  where expected :: Raster U p 3 3 Double
+        expected = fromRight . fromVector Seq $ U.fromList [ dia, dia, dia
+                                                           , dia, 1/2, dia
+                                                           , dia, dia, dia ]
+        dia = 8 + (1/2)
+        actual :: Raster U p 3 3 Double
+        actual = strict U . farea . strict B . fshape . fromRight . fromVector Seq $ U.fromList ([0,0,0,0,1,0,0,0,0] :: [Int])
+
+fareaComplex :: Assertion
+fareaComplex = let ?epsilon = 0.001 in actual @?~ (2 + (7 / 8) + (7 / 8) + (1 / 8))
+  where actual :: Double
+        actual = flip index' (1 :. 1) . _array . strict P $ farea rast
+        rast :: Raster B p 4 4 (Cell Int)
+        rast = strict B . fshape . fromRight . fromVector Seq $ U.fromList [1,1,1,0
+                                                                           ,1,0,0,0
+                                                                           ,1,0,0,1
+                                                                           ,1,0,1,1]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -87,7 +87,8 @@ suite = testGroup "Unit Tests"
       ]
     , testGroup "faspect"
       [ testCase "3x3 Flat" faspectFlat
-      , testCase "3x3 Hill" faspect45
+      , testCase "3x3 East" faspectEast
+      , testCase "3x3 South" faspect45
       ]
     ]
   ]
@@ -293,12 +294,12 @@ fgradientFlat = actual @?= expected
   where expected :: Raster U p 3 3 Double
         expected = fromRight . fromVector Seq $ U.fromList [0,0,0,0,0,0,0,0,0]
         actual :: Raster U p 3 3 Double
-        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList [1,1,1,1,1,1,1,1,1]
+        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
 
 fgradient45 :: Assertion
 fgradient45 = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?~ (tau / 8)
   where actual :: Raster U p 3 3 Double
-        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList [3,3,3,2,2,2,1,1,1]
+        actual = strict U . fgradient . fromRight . fromVector Seq $ U.fromList ([3,3,3,2,2,2,1,1,1] :: [Double])
 
 faspectFlat :: Assertion
 faspectFlat = (flip index' (1 :. 1) $ _array actual) @?= Nothing
@@ -309,3 +310,8 @@ faspect45 :: Assertion
 faspect45 = (flip index' (1 :. 1) $ _array actual) @?= Just (tau / 2)
   where actual :: Raster B p 3 3 (Maybe Double)
         actual = strict B . faspect . fromRight . fromVector Seq $ U.fromList ([3,3,3,2,2,2,1,1,1] :: [Double])
+
+faspectEast :: Assertion
+faspectEast = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?~ (tau / 4)
+  where actual :: Raster B p 3 3 Double
+        actual = strict B . faspect' . fromRight . fromVector Seq $ U.fromList ([3,2,1,3,2,1,3,2,1] :: [Double])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -90,6 +90,11 @@ suite = testGroup "Unit Tests"
       , testCase "3x3 East" faspectEast
       , testCase "3x3 South" faspect45
       ]
+    , testGroup "fdownstream"
+      [ testCase "3x3 Spikey" fdownstream4
+      , testCase "3x3 Flat" fdownstreamFlat
+      , testCase "3x3 Peak" fdownstreamPeak
+      ]
     ]
   ]
 
@@ -315,3 +320,18 @@ faspectEast :: Assertion
 faspectEast = let ?epsilon = 0.0001 in (flip index' (1 :. 1) $ _array actual) @?~ (tau / 4)
   where actual :: Raster B p 3 3 Double
         actual = strict B . faspect' . fromRight . fromVector Seq $ U.fromList ([3,2,1,3,2,1,3,2,1] :: [Double])
+
+fdownstream4 :: Assertion
+fdownstream4 = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [North,South,East,West]
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([3,1,3,1,2,1,3,1,3] :: [Double])
+
+fdownstreamFlat :: Assertion
+fdownstreamFlat = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [East ..]
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,1,1,1,1,1] :: [Double])
+
+fdownstreamPeak :: Assertion
+fdownstreamPeak = (flip index' (1 :. 1) $ _array actual) @?= S.fromList [NorthEast, NorthWest, SouthWest, SouthEast]
+  where actual :: Raster B p 3 3 (S.Set Direction)
+        actual = strict B . fdownstream . fromRight . fromVector Seq $ U.fromList ([1,1,1,1,3,1,1,1,1] :: [Double])


### PR DESCRIPTION
### TODO

- [x] FocalClassification
- [x] FocalLinkage, FocalLength (lineal conditions)
- [x] FocalPartition, FocalFrontage, FocalArea (areal conditions)
- [x] FocalVolume, FocalGradient, FocalAspect, FocalDrainage (surficial conditions)

**Omitted:** 
- FocalCombination (not useful as its own operation)
- FocalRanking (how is this different from FocalVariety?)
- FocalInsularity (unclear how it would operate in parallel. Seems to require `State`-like memory, hence it's monadic, hence it's serial)
- The variant of FocalFrontage and FocalArea that allow for also supplying an elevation layer